### PR TITLE
Snapshot.cs

### DIFF
--- a/GraphicalVersion/Snapshot.cs
+++ b/GraphicalVersion/Snapshot.cs
@@ -102,6 +102,11 @@ namespace GraphicalVersion
         public static bool convertToPDF(string uncompressedSnapshotName)
         {
             string outputPDF = Path.GetFileNameWithoutExtension(uncompressedSnapshotName) + ".pdf";
+            
+            /*
+             * The following string contains a path to a PDF file which doesn't exist
+             * This is used in the MergePDFDocuments function below
+             */
             string dummyPDF = Path.GetFileNameWithoutExtension(uncompressedSnapshotName) + "_dummy.pdf";
             bool r = false;
             try

--- a/GraphicalVersion/Snapshot.cs
+++ b/GraphicalVersion/Snapshot.cs
@@ -112,6 +112,13 @@ namespace GraphicalVersion
             try
             {
                 r = ConvertUncompressedSnapshot(uncompressedSnapshotName, outputPDF, 0, "", "", 0, 0, 0);
+                /*
+                 * ConvertUncompressedSnapshot function will produce a Secured PDF with random restrictions
+                 * 
+                 * This is a known issue.  A workaround is to call the MergePDFDocuments function using a
+                 * PDF that doesn't exist, as this will remove the security from the created PDF
+                 * 
+                 */
                 r = MergePDFDocuments(outputPDF, dummyPDF);
             }
             catch (DllNotFoundException)

--- a/GraphicalVersion/Snapshot.cs
+++ b/GraphicalVersion/Snapshot.cs
@@ -102,10 +102,12 @@ namespace GraphicalVersion
         public static bool convertToPDF(string uncompressedSnapshotName)
         {
             string outputPDF = Path.GetFileNameWithoutExtension(uncompressedSnapshotName) + ".pdf";
+            string dummyPDF = Path.GetFileNameWithoutExtension(uncompressedSnapshotName) + "_dummy.pdf";
             bool r = false;
             try
             {
                 r = ConvertUncompressedSnapshot(uncompressedSnapshotName, outputPDF, 0, "", "", 0, 0, 0);
+                r = MergePDFDocuments(outputPDF, dummyPDF);
             }
             catch (DllNotFoundException)
             {
@@ -150,5 +152,16 @@ namespace GraphicalVersion
                                                                long PDFNoFontEmbedding,
                                                                long PDFUnicodeFlags);
 
+         /*
+         * ConvertUncompressedSnapshot function will produce a Secured PDF with random restrictions
+         * 
+         * This is a known issue.  A workaround is to call the MergePDFDocuments function as using this will
+         * remove the security
+         * 
+         */
+      
+        [DllImport("StrStorage.dll")]
+        public static extern bool MergePDFDocuments(String firstPDF, String secondPDF);
+        
     }
 }


### PR DESCRIPTION
Added workaround to remove PDF document security properties from the converted file.  Original version will assign random security properties due to an issue with the ConvertUncompressedSnapshot function in the StrStorage.dll.